### PR TITLE
🌈: Añadido colorscheme a TailwindCSS config

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,26 +2,4 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
-}
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-  }
-}
-
-body {
-  color: rgb(var(--foreground-rgb));
-  background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb));
-}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="es">
-      <body className={inter.className}>{children}</body>
+      <body className={`${inter.className} bg-brand-light text-brand-dark dark:bg-brand-dark dark:text-brand-light`}>{children}</body>
     </html>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,23 +1,24 @@
-import "./globals.css";
-import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import './globals.css'
+import type { Metadata } from 'next'
 
-const inter = Inter({ subsets: ["latin"] });
+import { Inter } from 'next/font/google'
+
+const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  title: "Los Premios Discord Midudev 2023",
+  title: 'Los Premios Discord Midudev 2023',
   description:
-    "Es hora de revelar tus habilidades únicas. Participa en las categorías más originales y emocionantes del servidor de Midudev. ¡La gloria te espera!",
-};
+    'Es hora de revelar tus habilidades únicas. Participa en las categorías más originales y emocionantes del servidor de Midudev. ¡La gloria te espera!'
+}
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="es">
-      <body className={`${inter.className} bg-brand-light text-brand-dark dark:bg-brand-dark dark:text-brand-light`}>{children}</body>
+      <body
+        className={`${inter.className} bg-brand-light text-brand-dark dark:bg-brand-dark dark:text-brand-light`}
+      >
+        {children}
+      </body>
     </html>
-  );
+  )
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,16 @@ const config: Config = {
         'gradient-conic':
           'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
       },
+      theme: {
+        colors: {
+          'brand-light': '#F7F1F9',
+          'brand-dark': '#000000',
+          'brand-yellow': '#D3F527',
+          'brand-orange': '#FF930F',
+          'brand-purple': '#4A28F2',
+          'brand-lila': '#A998F8', 
+        },
+      },
     },
   },
   plugins: [],

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -4,14 +4,13 @@ const config: Config = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',
-    './app/**/*.{js,ts,jsx,tsx,mdx}',
+    './app/**/*.{js,ts,jsx,tsx,mdx}'
   ],
   theme: {
     extend: {
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
-        'gradient-conic':
-          'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
+        'gradient-conic': 'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))'
       },
       theme: {
         colors: {
@@ -20,11 +19,12 @@ const config: Config = {
           'brand-yellow': '#D3F527',
           'brand-orange': '#FF930F',
           'brand-purple': '#4A28F2',
-          'brand-lila': '#A998F8',
-        },
-      },
-    },
+          'brand-lila': '#A998F8'
+        }
+      }
+    }
   },
-  plugins: [],
+  plugins: []
 }
+
 export default config

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -20,7 +20,7 @@ const config: Config = {
           'brand-yellow': '#D3F527',
           'brand-orange': '#FF930F',
           'brand-purple': '#4A28F2',
-          'brand-lila': '#A998F8', 
+          'brand-lila': '#A998F8',
         },
       },
     },


### PR DESCRIPTION
Agregamos los colores de la marca, para implementar cómodamente con Tailwind. 

### Ejemplo:

```html
<button className="bg-brand-purple text-brand-light">Botón de Ejemplo</button>
```